### PR TITLE
spike(ui): add creatorFacet createVault action in admin UI

### DIFF
--- a/ui/src/components/Admin.tsx
+++ b/ui/src/components/Admin.tsx
@@ -268,6 +268,45 @@ const Admin: React.FC<AdminProps> = ({
     }
   };
 
+  const handleCreateVault = async () => {
+    if (!wallet || !keplr || !chainId || !watcherRef.current) {
+      alert('Wallet, Keplr, chain ID, or watcher not available');
+      return;
+    }
+
+    const targetAllocation = {
+      Aave_Base: 6000n,
+      Compound_Base: 4000n,
+    };
+
+    try {
+      const { target, tools } = reifyWalletEntry<{
+        createVault: (allocation: Record<string, bigint>) => Promise<{
+          portfolioId: number;
+          storagePath: string;
+        }>;
+      }>({
+        targetName: 'creatorFacet',
+        wallet,
+        keplr,
+        chainId,
+        marshaller: watcherRef.current.marshaller,
+        rpcEndpoint: ENDPOINTS.RPC,
+      });
+
+      trackInvocation(tools, 'createVault', 'creatorFacet');
+      const result = await target.createVault(targetAllocation);
+      alert(
+        `Vault creation submitted. portfolioId=${result.portfolioId}, storagePath=${result.storagePath}`,
+      );
+    } catch (error) {
+      console.error('Create vault failed:', error);
+      alert(
+        `Create vault failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  };
+
   const handleRedeemInvitation = async (description: string, saveName: string, replace: boolean) => {
     if (!wallet || !keplr || !chainId || !watcherRef.current) {
       alert('Wallet, Keplr, chain ID, or watcher not available');
@@ -653,6 +692,7 @@ const Admin: React.FC<AdminProps> = ({
           setPlannerAddress={setPlannerAddress}
           savedEntries={savedEntries}
           onDeliverPlannerInvitation={handleDeliverPlannerInvitation}
+          onCreateVault={handleCreateVault}
         />
 
         {pendingInvocations.size > 0 && (

--- a/ui/src/components/CreatorFacetCard.tsx
+++ b/ui/src/components/CreatorFacetCard.tsx
@@ -5,6 +5,7 @@ interface CreatorFacetCardProps {
   setPlannerAddress: (value: string) => void;
   savedEntries: Set<string>;
   onDeliverPlannerInvitation: () => void;
+  onCreateVault: () => void;
 }
 
 const CreatorFacetCard: React.FC<CreatorFacetCardProps> = ({
@@ -12,6 +13,7 @@ const CreatorFacetCard: React.FC<CreatorFacetCardProps> = ({
   setPlannerAddress,
   savedEntries,
   onDeliverPlannerInvitation,
+  onCreateVault,
 }) => {
   return (
     <div style={{ border: '2px solid #28a745', padding: '1rem', borderRadius: '8px', backgroundColor: '#f8fff8' }}>
@@ -49,6 +51,27 @@ const CreatorFacetCard: React.FC<CreatorFacetCardProps> = ({
           }}
         >
           Deliver
+        </button>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '0.75rem' }}>
+        <label style={{ minWidth: '140px', fontWeight: 'bold' }}>Create Vault:</label>
+        <div style={{ flex: 1, color: '#666', fontSize: '0.9em' }}>
+          60% Aave_Base / 40% Compound_Base (spike default)
+        </div>
+        <button
+          onClick={onCreateVault}
+          style={{
+            padding: '0.4rem 0.8rem',
+            backgroundColor: '#0d6efd',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: '0.9em',
+          }}
+        >
+          Create
         </button>
       </div>
     </div>


### PR DESCRIPTION
**WARNING: unreviewed LLM output**

## Goal
Provide a minimal UI control path for the vault spike so operators can trigger `creatorFacet.createVault(...)` from the prototype admin surface.

Related spike PRs:
- Agoric contract side: https://github.com/Agoric/agoric-sdk/pull/12513
- EVM contracts + smoke tooling: https://github.com/agoric-labs/agoric-to-axelar-local/pull/71

## Included
- Add `Create Vault` action to `CreatorFacetCard`
- Wire `Admin.tsx` handler to call `creatorFacet.createVault(...)`
- Use fixed spike allocation defaults (`Aave_Base: 6000`, `Compound_Base: 4000`)
- Show immediate result feedback (`portfolioId`, `storagePath`)

## Spike Posture
- Minimal implementation to unblock flow testing and demos.
- Not production UX.

## Out of Scope
- End-user vault UI routes/pages
- polished error/retry UX
- full type/lint cleanup for unrelated pre-existing issues in repo
