### PR TITLE
feat(ui): add DelegateAllocation signing flow in EVM wallet page

### DIFF
--- a/ui/src/components/DelegateAllocationForm.tsx
+++ b/ui/src/components/DelegateAllocationForm.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react';
+import {
+  isAddress,
+  type Account,
+  type Chain,
+  type Transport,
+  type WalletClient,
+} from 'viem';
+import { arbitrumSepolia as sepolia } from 'viem/chains';
+import type {
+  DelegateAllocationMessage,
+  SignedMessage,
+} from '../evm-portfolio-types';
+import {
+  ONE_HOUR_IN_SECONDS,
+  SEPOLIA_CONTRACTS,
+} from '../open-portfolio-eip712';
+
+interface Props {
+  userAddress: `0x${string}`;
+  walletClient: WalletClient<Transport, Chain, Account>;
+  onSigned: (result: SignedMessage) => void;
+}
+
+export function DelegateAllocationForm({
+  userAddress,
+  walletClient,
+  onSigned,
+}: Props) {
+  const [portfolioId, setPortfolioId] = useState('1');
+  const [delegateAddress, setDelegateAddress] = useState('');
+  const [signing, setSigning] = useState(false);
+  const [error, setError] = useState('');
+
+  const signMessage = async () => {
+    setSigning(true);
+    setError('');
+    try {
+      if (walletClient.chain.id !== sepolia.id) {
+        throw new Error(
+          `Wrong network: connected to chain ${walletClient.chain.id}, expected ${sepolia.id}`,
+        );
+      }
+      if (!/^\d+$/.test(portfolioId) || BigInt(portfolioId) <= 0n) {
+        throw new Error('Portfolio ID must be a positive integer');
+      }
+      if (!isAddress(delegateAddress)) {
+        throw new Error('Delegate address must be a valid EVM address');
+      }
+
+      const nonce = BigInt(`${Date.now()}`);
+      const deadline =
+        BigInt(Math.floor(Date.now() / 1000)) + ONE_HOUR_IN_SECONDS;
+
+      const data = {
+        domain: {
+          name: 'Ymax',
+          version: '1',
+          chainId: walletClient.chain.id,
+          verifyingContract: SEPOLIA_CONTRACTS.FACTORY,
+        },
+        types: {
+          EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+          ] as const,
+          DelegateAllocation: [
+            { name: 'address', type: 'address' },
+            { name: 'portfolio', type: 'uint256' },
+            { name: 'nonce', type: 'uint256' },
+            { name: 'deadline', type: 'uint256' },
+          ] as const,
+        },
+        primaryType: 'DelegateAllocation' as const,
+        message: {
+          portfolio: BigInt(portfolioId),
+          address: delegateAddress as `0x${string}`,
+          nonce,
+          deadline,
+        },
+      } satisfies Omit<DelegateAllocationMessage, 'signature'>;
+
+      const signature = await walletClient.signTypedData({
+        account: userAddress,
+        ...data,
+      });
+
+      onSigned({
+        ...data,
+        signature,
+      } satisfies DelegateAllocationMessage);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to sign message');
+    } finally {
+      setSigning(false);
+    }
+  };
+
+  return (
+    <div style={{ marginBottom: '30px' }}>
+      <h2>Delegate Allocation Control</h2>
+      <p style={{ color: '#666', fontSize: '14px' }}>
+        Sign a <code>DelegateAllocation</code> standalone EIP-712 operation.
+      </p>
+
+      <div style={{ marginBottom: '14px' }}>
+        <label
+          style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}
+        >
+          Portfolio ID:
+        </label>
+        <input
+          type="number"
+          min="1"
+          value={portfolioId}
+          onChange={e => setPortfolioId(e.target.value)}
+          disabled={signing}
+          style={{ padding: '8px', width: '200px' }}
+        />
+      </div>
+
+      <div style={{ marginBottom: '14px' }}>
+        <label
+          style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}
+        >
+          Delegate EVM Address:
+        </label>
+        <input
+          type="text"
+          value={delegateAddress}
+          onChange={e => setDelegateAddress(e.target.value.trim())}
+          disabled={signing}
+          placeholder="0x..."
+          style={{ padding: '8px', width: '100%', maxWidth: '480px' }}
+        />
+      </div>
+
+      {error && (
+        <div
+          style={{
+            marginBottom: '12px',
+            padding: '10px',
+            background: '#f8d7da',
+            border: '1px solid #f5c6cb',
+            color: '#721c24',
+            borderRadius: '4px',
+          }}
+        >
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      <button
+        onClick={signMessage}
+        disabled={signing}
+        style={{
+          padding: '10px 20px',
+          fontSize: '14px',
+          background: '#007bff',
+          color: 'white',
+          border: 'none',
+          borderRadius: '4px',
+          cursor: signing ? 'not-allowed' : 'pointer',
+          fontWeight: 'bold',
+          opacity: signing ? 0.6 : 1,
+        }}
+      >
+        {signing ? 'Signing...' : 'Sign DelegateAllocation'}
+      </button>
+    </div>
+  );
+}

--- a/ui/src/components/EVMWalletPage.tsx
+++ b/ui/src/components/EVMWalletPage.tsx
@@ -14,6 +14,7 @@ import {
   type WalletClient,
 } from 'viem';
 import { type CopyRecord, type Passable, makeMarshal } from '@endo/marshal';
+import { DelegateAllocationForm } from './DelegateAllocationForm';
 import { EVMWalletConnection } from './EVMWalletConnection';
 import { OpenPortfolioForm } from './OpenPortfolioForm';
 import type {
@@ -226,6 +227,7 @@ const mockEVMHandler = {
 };
 
 export function EVMWalletPage() {
+  const [mode, setMode] = useState<'open' | 'delegate'>('open');
   const [evmAddress, setEvmAddress] = useState<`0x${string}` | ''>('');
   const [walletClient, setWalletClient] = useState<WalletClient<
     Transport,
@@ -233,6 +235,7 @@ export function EVMWalletPage() {
     Account
   > | null>(null);
   const [signedData, setSignedData] = useState<SignedMessage | null>(null);
+  const [signedOperation, setSignedOperation] = useState<string>('');
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [txHash, setTxHash] = useState<string>('');
@@ -258,7 +261,20 @@ export function EVMWalletPage() {
   };
 
   const handleSigned = async (result: SignedMessage) => {
+    if (result.primaryType === 'DelegateAllocation') {
+      setSignedData(result);
+      setSignedOperation('DelegateAllocation');
+      setSubmitted(false);
+      setTxHash('');
+      setProgressLog([]);
+      setError('');
+      return;
+    }
+    const details = (await extractOperationDetailsFromSignedData(result)) as
+      | FullMessageDetails
+      | never;
     setSignedData(result);
+    setSignedOperation(details.operation);
     setSubmitted(false);
     setTxHash('');
     setProgressLog([]);
@@ -344,7 +360,7 @@ export function EVMWalletPage() {
     }
   };
 
-  const handleMockSubmit = () => {
+  const handleMockSubmit = async () => {
     if (!signedData) return;
 
     setProgressLog([]);
@@ -371,7 +387,24 @@ export function EVMWalletPage() {
     addProgress('Note: Nothing in this repository is production code.');
     addProgress('The "Submit to Sepolia (Direct)" button MOCKS steps 1-5.');
 
-    mockEVMHandler.handleOpenPortfolio(signedData);
+    if (signedData.primaryType === 'DelegateAllocation') {
+      addProgress('DelegateAllocation is standalone (no Permit2 payload).');
+      addProgress('Expected production flow: UI -> EMS -> EMH -> portfolio');
+      addProgress(
+        `Delegate operation for portfolio ${signedData.message.portfolio} to ${signedData.message.address}`,
+      );
+      console.log('DelegateAllocation signed payload:', signedData);
+    } else {
+      const details = (await extractOperationDetailsFromSignedData(
+        signedData,
+      )) as FullMessageDetails;
+      if (details.operation === 'OpenPortfolio') {
+        mockEVMHandler.handleOpenPortfolio(signedData);
+      } else {
+        addProgress(`Unsupported operation in mock flow: ${details.operation}`);
+        console.log('Unsupported signed payload:', signedData);
+      }
+    }
 
     setSubmitted(true);
   };
@@ -387,21 +420,72 @@ export function EVMWalletPage() {
     >
       <div style={{ marginBottom: '30px' }}>
         <h1 style={{ marginBottom: '10px' }}>Open Portfolio with EVM Wallet</h1>
+        <div style={{ display: 'flex', gap: '10px', marginBottom: '12px' }}>
+          <button
+            onClick={() => {
+              setMode('open');
+              setSignedData(null);
+              setSignedOperation('');
+              setSubmitted(false);
+              setTxHash('');
+              setProgressLog([]);
+              setError('');
+            }}
+            style={{
+              padding: '8px 12px',
+              borderRadius: '4px',
+              border: '1px solid #ccc',
+              background: mode === 'open' ? '#007bff' : 'white',
+              color: mode === 'open' ? 'white' : '#333',
+              cursor: 'pointer',
+            }}
+          >
+            Open Portfolio
+          </button>
+          <button
+            onClick={() => {
+              setMode('delegate');
+              setSignedData(null);
+              setSignedOperation('');
+              setSubmitted(false);
+              setTxHash('');
+              setProgressLog([]);
+              setError('');
+            }}
+            style={{
+              padding: '8px 12px',
+              borderRadius: '4px',
+              border: '1px solid #ccc',
+              background: mode === 'delegate' ? '#007bff' : 'white',
+              color: mode === 'delegate' ? 'white' : '#333',
+              cursor: 'pointer',
+            }}
+          >
+            Delegate Allocation
+          </button>
+        </div>
         <p style={{ color: '#666', fontSize: '14px' }}>
-          This page demonstrates EIP-712 signature collection for opening a Ymax
-          portfolio using an EVM wallet like MetaMask. You'll be prompted to
-          sign two messages:
+          This page demonstrates EIP-712 signature collection for Ymax
+          operations using an EVM wallet like MetaMask.
         </p>
-        <ol style={{ color: '#666', fontSize: '14px', marginTop: '10px' }}>
-          <li>
-            <strong>Permit2 Transfer:</strong> Allows the Factory contract to
-            move your USDC
-          </li>
-          <li>
-            <strong>OpenPortfolio Intent:</strong> Specifies deposit amount and
-            target allocations
-          </li>
-        </ol>
+        {mode === 'open' && (
+          <ol style={{ color: '#666', fontSize: '14px', marginTop: '10px' }}>
+            <li>
+              <strong>Permit2 Transfer:</strong> Allows the Factory contract to
+              move your USDC
+            </li>
+            <li>
+              <strong>OpenPortfolio Intent:</strong> Specifies deposit amount
+              and target allocations
+            </li>
+          </ol>
+        )}
+        {mode === 'delegate' && (
+          <p style={{ color: '#666', fontSize: '14px', marginTop: '10px' }}>
+            Delegate mode creates a standalone <code>DelegateAllocation</code>{' '}
+            message (no Permit2).
+          </p>
+        )}
         <p
           style={{
             color: '#856404',
@@ -421,7 +505,7 @@ export function EVMWalletPage() {
         </p>
       </div>
 
-      {usdcBalance !== null && (
+      {mode === 'open' && usdcBalance !== null && (
         <div
           style={{
             marginBottom: '20px',
@@ -450,8 +534,15 @@ export function EVMWalletPage() {
           onClientChange={setWalletClient}
         />
 
-        {evmAddress && walletClient && (
+        {evmAddress && walletClient && mode === 'open' && (
           <OpenPortfolioForm
+            userAddress={evmAddress}
+            walletClient={walletClient}
+            onSigned={handleSigned}
+          />
+        )}
+        {evmAddress && walletClient && mode === 'delegate' && (
+          <DelegateAllocationForm
             userAddress={evmAddress}
             walletClient={walletClient}
             onSigned={handleSigned}
@@ -476,7 +567,7 @@ export function EVMWalletPage() {
             <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
               <button
                 onClick={handleSubmitDirect}
-                disabled={submitting}
+                disabled={submitting || signedOperation !== 'OpenPortfolio'}
                 style={{
                   padding: '10px 20px',
                   fontSize: '14px',
@@ -489,7 +580,11 @@ export function EVMWalletPage() {
                   opacity: submitting ? 0.6 : 1,
                 }}
               >
-                {submitting ? 'Submitting...' : 'Submit to Sepolia (Direct)'}
+                {signedOperation === 'OpenPortfolio'
+                  ? submitting
+                    ? 'Submitting...'
+                    : 'Submit to Sepolia (Direct)'
+                  : 'Direct Submit (OpenPortfolio only)'}
               </button>
               <button
                 onClick={handleMockSubmit}

--- a/ui/src/evm-portfolio-types.ts
+++ b/ui/src/evm-portfolio-types.ts
@@ -14,11 +14,33 @@ import type { WithSignature } from '@agoric/orchestration/src/utils/viem.ts';
 
 export type { TargetAllocation };
 
+export type DelegateAllocationMessage = {
+  domain: {
+    name: 'Ymax';
+    version: '1';
+    chainId: bigint | number;
+    verifyingContract: Address;
+  };
+  types: {
+    EIP712Domain: readonly { name: string; type: string }[];
+    DelegateAllocation: readonly { name: string; type: string }[];
+  };
+  primaryType: 'DelegateAllocation';
+  message: {
+    address: Address;
+    portfolio: bigint;
+    nonce: bigint;
+    deadline: bigint;
+  };
+  signature: EVM_T<'bytes'>;
+};
+
 export type SignedMessage =
   | WithSignature<YmaxPermitWitnessTransferFromData<'OpenPortfolio'>>
   | WithSignature<YmaxPermitWitnessTransferFromData<'Rebalance'>>
   | WithSignature<YmaxStandaloneOperationData<'Rebalance'>>
   | WithSignature<YmaxPermitWitnessTransferFromData<'Deposit'>>
+  | DelegateAllocationMessage
   | never;
 
 /**


### PR DESCRIPTION
**WARNING: Unreviewed LLM output.**

## Summary
This PR adds `DelegateAllocation` support to the existing EVM wallet UI flow (no new route/page), so users can sign delegate operations directly from the same screen used for EIP-712 portfolio actions.

## What Changed
- Added a dedicated delegate signing form component:
  - New `Delegate Allocation` mode inputs for:
    - `portfolioId`
    - `delegateAddress`
  - Validates chain, portfolio id, and delegate address.
  - Produces and signs a standalone EIP-712 `DelegateAllocation` message.

- Extended signed-message typing used by the UI:
  - Added a `DelegateAllocationMessage` type.
  - Included it in `SignedMessage` union so the existing page can carry both permit-based and standalone operations.

- Integrated delegate mode into `EVMWalletPage`:
  - Added mode toggle: `Open Portfolio` / `Delegate Allocation`.
  - Reuses existing wallet connection and signed-message handling pipeline.
  - Keeps direct Sepolia submit enabled only for `OpenPortfolio`.
  - Adds delegate-aware mock logging for EMS/EMH relay expectations.

## Commit Structure (Atomic)
1. `feat(ui): add signed DelegateAllocation message type`
2. `feat(ui): add delegate allocation signing form`
3. `feat(ui): integrate delegate mode in EVM wallet flow`

## Files
- `ui/src/evm-portfolio-types.ts`
- `ui/src/components/DelegateAllocationForm.tsx`
- `ui/src/components/EVMWalletPage.tsx`

## Notes
- This branch was rebased onto `origin/mhofman/evm-lib` so the PR only includes the three delegate-related commits.
- Lint was run for touched files:
  - `ui/src/components/DelegateAllocationForm.tsx`
  - `ui/src/components/EVMWalletPage.tsx`
  - `ui/src/evm-portfolio-types.ts`
