### PR TITLE
test(ui): add camelCase wallet signing check

### DIFF
--- a/ui/src/components/DelegateAllocationForm.tsx
+++ b/ui/src/components/DelegateAllocationForm.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import {
-  isAddress,
   type Account,
   type Chain,
   type Transport,
@@ -28,7 +27,8 @@ export function DelegateAllocationForm({
   onSigned,
 }: Props) {
   const [portfolioId, setPortfolioId] = useState('1');
-  const [delegateAddress, setDelegateAddress] = useState('');
+  const [accountHolder, setAccountHolder] = useState('');
+  const [canSetAllocation, setCanSetAllocation] = useState(true);
   const [signing, setSigning] = useState(false);
   const [error, setError] = useState('');
 
@@ -44,8 +44,8 @@ export function DelegateAllocationForm({
       if (!/^\d+$/.test(portfolioId) || BigInt(portfolioId) <= 0n) {
         throw new Error('Portfolio ID must be a positive integer');
       }
-      if (!isAddress(delegateAddress)) {
-        throw new Error('Delegate address must be a valid EVM address');
+      if (!/^agoric1[0-9a-z]+$/.test(accountHolder)) {
+        throw new Error('Account holder must be a valid agoric1 address');
       }
 
       const nonce = BigInt(`${Date.now()}`);
@@ -67,16 +67,18 @@ export function DelegateAllocationForm({
             { name: 'verifyingContract', type: 'address' },
           ] as const,
           DelegateAllocation: [
-            { name: 'address', type: 'address' },
+            { name: 'accountHolder', type: 'string' },
             { name: 'portfolio', type: 'uint256' },
+            { name: 'canSetAllocation', type: 'bool' },
             { name: 'nonce', type: 'uint256' },
             { name: 'deadline', type: 'uint256' },
           ] as const,
         },
         primaryType: 'DelegateAllocation' as const,
         message: {
+          accountHolder,
           portfolio: BigInt(portfolioId),
-          address: delegateAddress as `0x${string}`,
+          canSetAllocation,
           nonce,
           deadline,
         },
@@ -102,7 +104,8 @@ export function DelegateAllocationForm({
     <div style={{ marginBottom: '30px' }}>
       <h2>Delegate Allocation Control</h2>
       <p style={{ color: '#666', fontSize: '14px' }}>
-        Sign a <code>DelegateAllocation</code> standalone EIP-712 operation.
+        Sign a standalone <code>DelegateAllocation</code> EIP-712 operation
+        with a camelCase field named <code>accountHolder</code>.
       </p>
 
       <div style={{ marginBottom: '14px' }}>
@@ -125,17 +128,34 @@ export function DelegateAllocationForm({
         <label
           style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}
         >
-          Delegate EVM Address:
+          Account Holder Address:
         </label>
         <input
           type="text"
-          value={delegateAddress}
-          onChange={e => setDelegateAddress(e.target.value.trim())}
+          value={accountHolder}
+          onChange={e => setAccountHolder(e.target.value.trim())}
           disabled={signing}
-          placeholder="0x..."
+          placeholder="agoric1..."
           style={{ padding: '8px', width: '100%', maxWidth: '480px' }}
         />
       </div>
+
+      <label
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+          marginBottom: '14px',
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={canSetAllocation}
+          onChange={e => setCanSetAllocation(e.target.checked)}
+          disabled={signing}
+        />
+        Allow allocation updates
+      </label>
 
       {error && (
         <div

--- a/ui/src/components/EVMWalletPage.tsx
+++ b/ui/src/components/EVMWalletPage.tsx
@@ -31,8 +31,8 @@ import { useSepoliaPublicClient } from '../utils/sepoliaPublicClient.ts';
 import type {
   YmaxPermitWitnessTransferFromData,
   YmaxStandaloneOperationData,
-} from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.ts';
-import type { WithSignature } from '@agoric/orchestration/src/utils/viem.ts';
+} from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.js';
+import type { WithSignature } from '@agoric/orchestration/src/utils/viem.js';
 import {
   extractOperationDetailsFromSignedData,
   type FullMessageDetails,
@@ -62,6 +62,65 @@ type InvokeEntryMessage = {
 type InvokeStoreEntryAction = {
   method: 'invokeEntry';
   message: InvokeEntryMessage;
+};
+
+type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+type EvmOperationSubmitResponse = {
+  id: number;
+  owner: string;
+  status: 'transacted' | 'failed';
+  txHash: string | null;
+  error: string | null;
+  timestamp: string;
+};
+
+const ESCAPE_CHARS = /^[!"#$%&'()*+,-]/;
+const DEFAULT_EMS_BASE_URL = 'https://dev0.ymax.app';
+
+const toSmallcaps = (value: unknown): JsonValue => {
+  if (value === undefined) return '#undefined';
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) return '#NaN';
+    if (value === Infinity) return '#Infinity';
+    if (value === -Infinity) return '#-Infinity';
+    if (Object.is(value, -0)) return 0;
+    return value;
+  }
+  if (typeof value === 'bigint') return value >= 0n ? `+${value}` : `${value}`;
+  if (typeof value === 'string')
+    return ESCAPE_CHARS.test(value) ? `!${value}` : value;
+  if (typeof value === 'boolean' || value === null) return value;
+  if (Array.isArray(value)) return value.map(toSmallcaps);
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, toSmallcaps(v)]),
+    );
+  }
+  throw new Error(`unsupported value for smallcaps: ${String(value)}`);
+};
+
+const isEvmOperationSubmitResponse = (
+  value: unknown,
+): value is EvmOperationSubmitResponse => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const rec = value as Record<string, unknown>;
+  return (
+    typeof rec.id === 'number' &&
+    typeof rec.owner === 'string' &&
+    (rec.status === 'transacted' || rec.status === 'failed') &&
+    (typeof rec.txHash === 'string' || rec.txHash === null) &&
+    (typeof rec.error === 'string' || rec.error === null) &&
+    typeof rec.timestamp === 'string'
+  );
 };
 
 /**
@@ -388,10 +447,11 @@ export function EVMWalletPage() {
     addProgress('The "Submit to Sepolia (Direct)" button MOCKS steps 1-5.');
 
     if (signedData.primaryType === 'DelegateAllocation') {
-      addProgress('DelegateAllocation is standalone (no Permit2 payload).');
-      addProgress('Expected production flow: UI -> EMS -> EMH -> portfolio');
       addProgress(
-        `Delegate operation for portfolio ${signedData.message.portfolio} to ${signedData.message.address}`,
+        'DelegateAllocation is a standalone operation (no Permit2 payload).',
+      );
+      addProgress(
+        `camelCase field accountHolder=${signedData.message.accountHolder}`,
       );
       console.log('DelegateAllocation signed payload:', signedData);
     } else {
@@ -407,6 +467,74 @@ export function EVMWalletPage() {
     }
 
     setSubmitted(true);
+  };
+
+  const handleSubmitStandaloneToEms = async () => {
+    if (!signedData || signedData.primaryType !== 'DelegateAllocation') {
+      return;
+    }
+
+    setSubmitting(true);
+    setError('');
+    setProgressLog([]);
+    setTxHash('');
+
+    try {
+      const emsBaseUrl =
+        import.meta.env.VITE_YDS_PROXY_TARGET ?? DEFAULT_EMS_BASE_URL;
+      const endpoint = new URL('/evm-operations', emsBaseUrl);
+      addProgress(`Submitting DelegateAllocation to EMS: ${endpoint}`);
+
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(toSmallcaps(signedData)),
+      });
+
+      if (!response.ok) {
+        const rawBody = await response.text();
+        let bodyForMessage = rawBody;
+        try {
+          const parsed = JSON.parse(rawBody);
+          bodyForMessage = JSON.stringify(parsed);
+        } catch {
+          // Keep raw body when it isn't JSON.
+        }
+        throw new Error(
+          `EMS HTTP ${response.status} ${response.statusText}; body: ${bodyForMessage || '<empty>'}`,
+        );
+      }
+
+      const result = await response.json();
+      if (!isEvmOperationSubmitResponse(result)) {
+        throw new Error('Unexpected EMS response shape');
+      }
+
+      if (result.status === 'failed') {
+        throw new Error(result.error ?? 'EMS submission failed');
+      }
+
+      if (result.txHash) {
+        setTxHash(result.txHash);
+        addProgress(
+          `EMS accepted operation ${result.id} with tx ${result.txHash}`,
+        );
+      } else {
+        addProgress(`EMS accepted operation ${result.id}`);
+      }
+
+      setSubmitted(true);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'Failed to submit standalone operation to EMS';
+      setError(message);
+      addProgress(`✗ Error: ${message}`);
+      console.error('Standalone EMS submission error:', err);
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -483,7 +611,7 @@ export function EVMWalletPage() {
         {mode === 'delegate' && (
           <p style={{ color: '#666', fontSize: '14px', marginTop: '10px' }}>
             Delegate mode creates a standalone <code>DelegateAllocation</code>{' '}
-            message (no Permit2).
+            message with a camelCase field named <code>accountHolder</code>.
           </p>
         )}
         <p
@@ -587,7 +715,11 @@ export function EVMWalletPage() {
                   : 'Direct Submit (OpenPortfolio only)'}
               </button>
               <button
-                onClick={handleMockSubmit}
+                onClick={
+                  signedOperation === 'DelegateAllocation'
+                    ? handleSubmitStandaloneToEms
+                    : handleMockSubmit
+                }
                 disabled={submitting}
                 style={{
                   padding: '10px 20px',
@@ -601,7 +733,11 @@ export function EVMWalletPage() {
                   opacity: submitting ? 0.6 : 1,
                 }}
               >
-                View Mock Flow (Console)
+                {signedOperation === 'DelegateAllocation'
+                  ? submitting
+                    ? 'Submitting to EMS...'
+                    : 'Submit DelegateAllocation to EMS'
+                  : 'View Mock Flow (Console)'}
               </button>
             </div>
           </div>

--- a/ui/src/evm-portfolio-types.ts
+++ b/ui/src/evm-portfolio-types.ts
@@ -7,10 +7,10 @@ import type {
   TargetAllocation,
   YmaxPermitWitnessTransferFromData,
   YmaxStandaloneOperationData,
-} from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.ts';
-import type { PermitTransferFrom } from '@agoric/orchestration/src/utils/permit2.ts';
+} from '@agoric/portfolio-api/src/evm-wallet/eip712-messages.js';
+import type { PermitTransferFrom } from '@agoric/orchestration/src/utils/permit2.js';
 import type { Bech32Address } from '@agoric/cosmic-proto/address-hooks.js';
-import type { WithSignature } from '@agoric/orchestration/src/utils/viem.ts';
+import type { WithSignature } from '@agoric/orchestration/src/utils/viem.js';
 
 export type { TargetAllocation };
 
@@ -27,8 +27,9 @@ export type DelegateAllocationMessage = {
   };
   primaryType: 'DelegateAllocation';
   message: {
-    address: Address;
+    accountHolder: string;
     portfolio: bigint;
+    canSetAllocation: boolean;
     nonce: bigint;
     deadline: bigint;
   };


### PR DESCRIPTION
refs
 - https://github.com/Agoric/agoric-sdk/pull/12688#discussion_r3335684303

## Summary
- change the delegate signing test payload to use camelCase fields such as \
- switch the delegate form from EVM delegate address input to an Agoric account holder input
- keep the delegate flow local so wallet rendering can be tested without backend/schema dependency changes

## Testing
- yarn start:ui
- connect MetaMask to Arbitrum Sepolia and sign the DelegateAllocation payload